### PR TITLE
fixes get table endpoint, adds get table names endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -131,7 +131,7 @@ paths:
                 type: string
                 description: software_version
   /powerautomate/automations/direct/workflows/0438716ee92b4378811dbc975401decd/triggers/manual/paths/invoke:
-    get:
+    post:
       responses:
         '200':
           description: default


### PR DESCRIPTION
This PR:
- Fixes get table endpoint by adding a parameter for "table_name" (flow was updated to expect "table_name' instead of "tableName" to match other flows)
- Adds endpoint for get_table_names which will return a list of table names in env