### PR TITLE
fix: fixes response definitions for GET requests

### DIFF
--- a/aind_api_connector_dev_openapi.yaml
+++ b/aind_api_connector_dev_openapi.yaml
@@ -232,9 +232,11 @@ paths:
   /powerautomate/automations/direct/workflows/0438716ee92b4378811dbc975401decd/triggers/manual/paths/invoke:
     post:
       responses:
-        default:
+        '200':
           description: default
-          schema: {}
+          schema:
+            type: object
+            properties: {}
       operationId: GetTableData
       summary: Get Table Data
       description: Gets all data for a table
@@ -271,9 +273,11 @@ paths:
   /powerautomate/automations/direct/workflows/70452d9b21584637a8023e3d66fc37ea/triggers/manual/paths/invoke:
     post:
       responses:
-        default:
+        '200':
           description: default
-          schema: {}
+          schema:
+            type: object
+            properties: {}
       operationId: GetTableNames
       summary: Get Table Name
       description: Gets all dataverse table names

--- a/aind_api_connector_prod_openapi.yaml
+++ b/aind_api_connector_prod_openapi.yaml
@@ -223,9 +223,11 @@ paths:
   /powerautomate/automations/direct/workflows/f6c21f9b55034601ada7ade802482d08/triggers/manual/paths/invoke:
     post:
       responses:
-        default:
+        '200':
           description: default
-          schema: {}
+          schema:
+            type: object
+            properties: {}
       summary: Get Table Data
       description: returns all data for a table
       operationId: GetTableData
@@ -262,9 +264,11 @@ paths:
   /powerautomate/automations/direct/workflows/2be3b0f7123e46b7b56e25dbf1c3c302/triggers/manual/paths/invoke:
     post:
       responses:
-        default:
+        '200':
           description: default
-          schema: {}
+          schema:
+            type: object
+            properties: {}
       summary: Get Table Names
       description: Retrieves table names in dataverse
       operationId: GetTableNames


### PR DESCRIPTION
closes #25 

This PR updates the response definitions of both `GetTableData` and `GetTableNames` actions. To keep it simple, both are expecting some response with an undefined schema (leaves it loose; schemas can be handled downstreamif necessary).

Tested generating the API locally and confirmed it works as expected!  